### PR TITLE
Replaced faulty API key

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="">
     <meta name="author" content="Benedetto Lo Giudice">
     <link rel="stylesheet" href="css/style.css" type="text/css">
-    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDgUQ1n-me0Lb0QVVSdgHSxSGFw_pmvr9A&libraries=geometry">
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyATGpHWEQDpfqQVAkuPDGcsUkR-TmFK0ro&libraries=geometry">
     </script>
 </head>
 <body>


### PR DESCRIPTION
I don't know why, but the existing Gmaps API keys doesn't work anymore. I have generated a new one.
